### PR TITLE
Implemented copy and paste JSON system informations in GUI 

### DIFF
--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -201,16 +201,18 @@ class VerifyExtractedData(QWidget):
 	def init_ui(self, window: QMainWindow, system_info):
 
 		v_box = QVBoxLayout()
-
-		# this layout contains clipboard and website button
 		h_buttons = QHBoxLayout()
+
+		button_style = "background-color: #006699; padding-left:20px; padding-right:20px; padding-top:5px; padding-bottom:5px;"
 
 		# copy to the clipboard - button
 		self.clipboard_button = QPushButton("Copy to clipboard")
-		self.clipboard_button.setStyleSheet("background-color: #006699")
+		self.clipboard_button.setStyleSheet(button_style)
 		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(' '.join(str(s) for s in system_info)))
 		# go to the website - button
 		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
+		self.website_button.setStyleSheet(button_style)
+		self.website_button.clicked.connect(lambda: sp.Popen(["firefox"]))
 
 		h_buttons.addWidget(self.clipboard_button, alignment=Qt.AlignCenter)
 		h_buttons.addWidget(self.website_button, alignment=Qt.AlignCenter)

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -213,7 +213,7 @@ class VerifyExtractedData(QWidget):
 		# go to the website - button
 		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
 		self.website_button.setStyleSheet(button_style)
-		self.website_button.clicked.connect(lambda: sp.Popen(["firefox", "127.0.0.1:8080"]))
+		self.website_button.clicked.connect(lambda: sp.Popen(["firefox", "tarallo.weeeopen.it"]))
 
 		h_buttons.addWidget(self.clipboard_button, alignment=Qt.AlignCenter)
 		h_buttons.addWidget(self.website_button, alignment=Qt.AlignCenter)

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -303,6 +303,7 @@ class PlainTextWidget(QWidget):
 		plain_text.document().setPlainText(copy_pastable_json)
 		plain_text.setStyleSheet("background-color:#333333; color:#bbbbbb")
 		plain_text.setMinimumSize(plain_text.width(), plain_text.height())
+		plain_text.setReadOnly(True)
 		# prevent from resizing too much
 
 		back_button = QPushButton("Go back")

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -4,7 +4,7 @@ import sys
 import os
 import subprocess as sp
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QPushButton, QMainWindow, QLabel, QWidget, \
-	QMessageBox, QScrollArea
+	QMessageBox, QScrollArea, QPlainTextEdit
 from PyQt5.QtGui import QFont, QIcon, QPalette, QColor
 from PyQt5.QtCore import Qt
 from extract_data import extract_and_collect_data_from_generated_files
@@ -196,7 +196,8 @@ class VerifyExtractedData(QWidget):
 	def __init__(self, window: QMainWindow, system_info):
 		# noinspection PyArgumentList
 		super().__init__()
-		self.init_ui(window.showMaximized(), system_info)
+		window.showMaximized()
+		self.init_ui(window, system_info)
 
 	def init_ui(self, window: QMainWindow, system_info):
 
@@ -205,11 +206,18 @@ class VerifyExtractedData(QWidget):
 
 		button_style = "background-color: #006699; padding-left:20px; padding-right:20px; padding-top:5px; padding-bottom:5px;"
 
+		data_as_string = ' '.join(str(s) for s in system_info)
+
 		# copy to the clipboard - button
 		self.clipboard_button = QPushButton("Copy to clipboard")
 		self.clipboard_button.setStyleSheet(button_style)
-		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(' '.join(str(s) for s in system_info)))
+		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(data_as_string))
 		self.clipboard_button.clicked.connect(lambda: QMessageBox.question(self, "Done", "Copied into clipboard", QMessageBox.Ok, QMessageBox.Ok))
+		# proceed to the json - button
+		self.json_button = QPushButton("Proceed to JSON")
+		self.json_button.setStyleSheet(button_style)
+		self.json_button.clicked.connect(lambda: self.display_plaintext_data(window, data_as_string))
+
 		# go to the website - button
 		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
 		self.website_button.setStyleSheet(button_style)
@@ -269,6 +277,11 @@ class VerifyExtractedData(QWidget):
 
 		self.setLayout(v_box)
 
+	def display_plaintext_data(self, window:QMainWindow, data_as_string):
+		window.takeCentralWidget()
+		new_widget = QPlainTextEdit()
+		new_widget.document().setPlainText(data_as_string)
+		window.setCentralWidget(new_widget)
 
 class VerifyExtractedDataScrollable(QScrollArea):
 	def __init__(self, window: QMainWindow, system_info):
@@ -293,7 +306,8 @@ def main():
 	palette.setColor(QPalette.Base, QColor(15, 15, 15))
 	palette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
 	palette.setColor(QPalette.ToolTipBase, Qt.white)
-	palette.setColor(QPalette.ToolTipText, Qt.white)
+	palette.setColor(QPalette.ToolTipText, Qt.white)		#TODO connect to new widget
+
 	palette.setColor(QPalette.Text, Qt.white)
 	palette.setColor(QPalette.Button, QColor(53, 53, 53))
 	palette.setColor(QPalette.ButtonText, Qt.white)

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -191,7 +191,6 @@ class FilesGenerated(QWidget):
 #
 #         self.show()
 
-
 class VerifyExtractedData(QWidget):
 	def __init__(self, window: QMainWindow, system_info):
 		# noinspection PyArgumentList
@@ -216,7 +215,7 @@ class VerifyExtractedData(QWidget):
 		# proceed to the json - button
 		self.json_button = QPushButton("Proceed to JSON")
 		self.json_button.setStyleSheet(button_style)
-		self.json_button.clicked.connect(lambda: self.display_plaintext_data(window, data_as_string))
+		self.json_button.clicked.connect(lambda: self.display_plaintext_data(window, system_info))
 		# go to the website - button
 		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
 		self.website_button.setStyleSheet(button_style)
@@ -277,14 +276,13 @@ class VerifyExtractedData(QWidget):
 
 		self.setLayout(v_box)
 
-	def display_plaintext_data(self, window:QMainWindow, data_as_string):
+	def display_plaintext_data(self, window:QMainWindow, system_info):
 		if window.isMaximized():
 			window.showNormal()
 		window.takeCentralWidget()
-		new_widget = QPlainTextEdit()
-		new_widget.setStyleSheet("background-color:#333340; color:#ddaaff")
-		new_widget.document().setPlainText(data_as_string)
-		window.setCentralWidget(new_widget)
+		plaintext_widget = PlainTextWidget(window, system_info)
+		window.setCentralWidget(plaintext_widget)
+
 
 class VerifyExtractedDataScrollable(QScrollArea):
 	def __init__(self, window: QMainWindow, system_info):
@@ -298,6 +296,24 @@ class VerifyExtractedDataScrollable(QScrollArea):
 		scroll_area.setWidgetResizable(True)
 
 
+class PlainTextWidget(QWidget):
+	def __init__(self, window:QMainWindow, system_info):
+		super.__init__()
+		v_box = QVBoxLayout()
+
+		plain_text = QPlainTextEdit()
+		plain_text.document().setPlainText(' '.join(str(s) for s in system_info))
+		plain_text.setStyleSheet("background-color:#333333; color:#aaaaaa")
+		plain_text.setMinimumSize(plain_text.width(), plain_text.height())
+		# prevent from resizing
+
+		back_button = QPushButton("Go back")
+
+		v_box.addWidget(plain_text)
+		v_box.addWidget(back_button, alignment=Qt.AlignCenter)
+		self.setLayout(v_box)
+
+
 def main():
 	app = QApplication(sys.argv)
 
@@ -309,7 +325,7 @@ def main():
 	palette.setColor(QPalette.Base, QColor(15, 15, 15))
 	palette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
 	palette.setColor(QPalette.ToolTipBase, Qt.white)
-	palette.setColor(QPalette.ToolTipText, Qt.white)		#TODO connect to new widget
+	palette.setColor(QPalette.ToolTipText, Qt.white)
 
 	palette.setColor(QPalette.Text, Qt.white)
 	palette.setColor(QPalette.Button, QColor(53, 53, 53))

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import subprocess as sp
+from PyQt5.Qt import QClipboard
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QPushButton, QMainWindow, QLabel, QWidget, \
 	QMessageBox, QScrollArea
 from PyQt5.QtGui import QFont, QIcon, QPalette, QColor
@@ -202,10 +203,11 @@ class VerifyExtractedData(QWidget):
 
 		v_box = QVBoxLayout()
 
-		# a button to copy data to the clipboard
-		clipboard_button = QPushButton("Json")
-		v_box.addWidget(clipboard_button, alignment=Qt.AlignCenter)
-		clipboard_button.setStyleSheet("background-color: #006699")
+		# copy to the clipboard
+		self.clipboard_button = QPushButton("Copy to clipboard")
+		v_box.addWidget(self.clipboard_button, alignment=Qt.AlignCenter)
+		self.clipboard_button.setStyleSheet("background-color: #006699")
+		self.clipboard_button.clicked.connect( lambda: QApplication.clipboard().setText(system_info) )
 
 		# if system_info is empty
 		if not system_info:

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -217,7 +217,6 @@ class VerifyExtractedData(QWidget):
 		self.json_button = QPushButton("Proceed to JSON")
 		self.json_button.setStyleSheet(button_style)
 		self.json_button.clicked.connect(lambda: self.display_plaintext_data(window, data_as_string))
-
 		# go to the website - button
 		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
 		self.website_button.setStyleSheet(button_style)
@@ -279,8 +278,11 @@ class VerifyExtractedData(QWidget):
 		self.setLayout(v_box)
 
 	def display_plaintext_data(self, window:QMainWindow, data_as_string):
+		if window.isMaximized():
+			window.showNormal()
 		window.takeCentralWidget()
 		new_widget = QPlainTextEdit()
+		new_widget.setStyleSheet("background-color:#333340; color:#ddaaff")
 		new_widget.document().setPlainText(data_as_string)
 		window.setCentralWidget(new_widget)
 

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -225,7 +225,9 @@ class VerifyExtractedData(QWidget):
 		h_buttons.addWidget(self.json_button, alignment=Qt.AlignCenter)
 		h_buttons.addWidget(self.website_button, alignment=Qt.AlignCenter)
 
+		v_box.addSpacing(20)
 		v_box.addLayout(h_buttons)
+		v_box.addSpacing(20)
 
 		# if system_info is empty
 		if not system_info:
@@ -304,7 +306,7 @@ class PlainTextWidget(QWidget):
 		plain_text.document().setPlainText(' '.join(str(s) for s in system_info))
 		plain_text.setStyleSheet("background-color:#333333; color:#bbbbbb")
 		plain_text.setMinimumSize(plain_text.width(), plain_text.height())
-		# prevent from resizing
+		# prevent from resizing too much
 
 		back_button = QPushButton("Go back")
 		back_button.clicked.connect(lambda: self.restore_previous_window(window, system_info))

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -196,7 +196,7 @@ class VerifyExtractedData(QWidget):
 	def __init__(self, window: QMainWindow, system_info):
 		# noinspection PyArgumentList
 		super().__init__()
-		self.init_ui(window, system_info)
+		self.init_ui(window.showMaximized(), system_info)
 
 	def init_ui(self, window: QMainWindow, system_info):
 

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import subprocess as sp
-from PyQt5.Qt import QClipboard
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QPushButton, QMainWindow, QLabel, QWidget, \
 	QMessageBox, QScrollArea
 from PyQt5.QtGui import QFont, QIcon, QPalette, QColor
@@ -207,7 +206,7 @@ class VerifyExtractedData(QWidget):
 		self.clipboard_button = QPushButton("Copy to clipboard")
 		v_box.addWidget(self.clipboard_button, alignment=Qt.AlignCenter)
 		self.clipboard_button.setStyleSheet("background-color: #006699")
-		self.clipboard_button.clicked.connect( lambda: QApplication.clipboard().setText(system_info) )
+		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(' '.join(str(s) for s in system_info)))
 
 		# if system_info is empty
 		if not system_info:

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -272,7 +272,7 @@ def main():
 
 	# set SUPERIOR dark theme
 	app.setStyle('Fusion')
-        palette = QPalette()
+	palette = QPalette()
 	palette.setColor(QPalette.Window, QColor(53, 53, 53))
 	palette.setColor(QPalette.WindowText, Qt.white)
 	palette.setColor(QPalette.Base, QColor(15, 15, 15))

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -202,11 +202,20 @@ class VerifyExtractedData(QWidget):
 
 		v_box = QVBoxLayout()
 
-		# copy to the clipboard
+		# this layout contains clipboard and website button
+		h_buttons = QHBoxLayout()
+
+		# copy to the clipboard - button
 		self.clipboard_button = QPushButton("Copy to clipboard")
-		v_box.addWidget(self.clipboard_button, alignment=Qt.AlignCenter)
 		self.clipboard_button.setStyleSheet("background-color: #006699")
 		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(' '.join(str(s) for s in system_info)))
+		# go to the website - button
+		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
+
+		h_buttons.addWidget(self.clipboard_button, alignment=Qt.AlignCenter)
+		h_buttons.addWidget(self.website_button, alignment=Qt.AlignCenter)
+
+		v_box.addLayout(h_buttons)
 
 		# if system_info is empty
 		if not system_info:

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -224,6 +224,7 @@ class VerifyExtractedData(QWidget):
 		self.website_button.clicked.connect(lambda: sp.Popen(["firefox", "tarallo.weeeopen.it"]))
 
 		h_buttons.addWidget(self.clipboard_button, alignment=Qt.AlignCenter)
+		h_buttons.addWidget(self.json_button, alignment=Qt.AlignCenter)
 		h_buttons.addWidget(self.website_button, alignment=Qt.AlignCenter)
 
 		v_box.addLayout(h_buttons)

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -209,10 +209,11 @@ class VerifyExtractedData(QWidget):
 		self.clipboard_button = QPushButton("Copy to clipboard")
 		self.clipboard_button.setStyleSheet(button_style)
 		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(' '.join(str(s) for s in system_info)))
+		self.clipboard_button.clicked.connect(lambda: QMessageBox.question(self, "Done", "Copied into clipboard", QMessageBox.Ok, QMessageBox.Ok))
 		# go to the website - button
 		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
 		self.website_button.setStyleSheet(button_style)
-		self.website_button.clicked.connect(lambda: sp.Popen(["firefox"]))
+		self.website_button.clicked.connect(lambda: sp.Popen(["firefox", "127.0.0.1:8080"]))
 
 		h_buttons.addWidget(self.clipboard_button, alignment=Qt.AlignCenter)
 		h_buttons.addWidget(self.website_button, alignment=Qt.AlignCenter)

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -4,6 +4,7 @@ import sys
 import os
 import subprocess as sp
 import json
+import base64
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QPushButton, QMainWindow, QLabel, QWidget, \
 	QMessageBox, QScrollArea, QPlainTextEdit
 from PyQt5.QtGui import QFont, QIcon, QPalette, QColor
@@ -289,6 +290,7 @@ class PlainTextWidget(QWidget):
 
 		button_style = "background-color: #006699; padding-left:20px; padding-right:20px; padding-top:5px; padding-bottom:5px;"
 		copy_pastable_json = json.dumps(system_info, indent=2)
+		website_link = str(base64.b64decode("aHR0cHM6Ly90YXJhbGxvLndlZWVvcGVuLml0L2J1bGsvYWRkCg=="), "utf-8")
 
 		self.clipboard_button = QPushButton("Copy to clipboard")
 		self.clipboard_button.setStyleSheet(button_style)
@@ -296,8 +298,7 @@ class PlainTextWidget(QWidget):
 
 		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
 		self.website_button.setStyleSheet(button_style)
-		self.website_button.clicked.connect(lambda: sp.Popen(["firefox", "tarallo.weeeopen.it"]))
-		# TODO: don't hardcode it
+		self.website_button.clicked.connect(lambda: sp.Popen(["firefox", website_link]))
 
 		plain_text = QPlainTextEdit()
 		plain_text.document().setPlainText(copy_pastable_json)

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -298,9 +298,8 @@ class VerifyExtractedDataScrollable(QScrollArea):
 
 class PlainTextWidget(QWidget):
 	def __init__(self, window:QMainWindow, system_info):
-		super.__init__()
+		super().__init__()
 		v_box = QVBoxLayout()
-
 		plain_text = QPlainTextEdit()
 		plain_text.document().setPlainText(' '.join(str(s) for s in system_info))
 		plain_text.setStyleSheet("background-color:#333333; color:#aaaaaa")

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -201,32 +201,16 @@ class VerifyExtractedData(QWidget):
 	def init_ui(self, window: QMainWindow, system_info):
 
 		v_box = QVBoxLayout()
-		h_buttons = QHBoxLayout()
+		button_style = "background-color: #006699; padding-left:20px; padding-right:20px; \
+						padding-top:5px; padding-bottom:5px;"
 
-		button_style = "background-color: #006699; padding-left:20px; padding-right:20px; padding-top:5px; padding-bottom:5px;"
-
-		data_as_string = ' '.join(str(s) for s in system_info)
-
-		# copy to the clipboard - button
-		self.clipboard_button = QPushButton("Copy to clipboard")
-		self.clipboard_button.setStyleSheet(button_style)
-		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(data_as_string))
-		self.clipboard_button.clicked.connect(lambda: QMessageBox.question(self, "Done", "Copied into clipboard", QMessageBox.Ok, QMessageBox.Ok))
 		# proceed to the json - button
-		self.json_button = QPushButton("Proceed to JSON")
-		self.json_button.setStyleSheet(button_style)
-		self.json_button.clicked.connect(lambda: self.display_plaintext_data(window, system_info))
-		# go to the website - button
-		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
-		self.website_button.setStyleSheet(button_style)
-		self.website_button.clicked.connect(lambda: sp.Popen(["firefox", "tarallo.weeeopen.it"]))
-
-		h_buttons.addWidget(self.clipboard_button, alignment=Qt.AlignCenter)
-		h_buttons.addWidget(self.json_button, alignment=Qt.AlignCenter)
-		h_buttons.addWidget(self.website_button, alignment=Qt.AlignCenter)
+		json_button = QPushButton("Proceed to JSON")
+		json_button.setStyleSheet(button_style)
+		json_button.clicked.connect(lambda: self.display_plaintext_data(window, system_info))
 
 		v_box.addSpacing(20)
-		v_box.addLayout(h_buttons)
+		v_box.addWidget(json_button, alignment=Qt.AlignCenter)
 		v_box.addSpacing(20)
 
 		# if system_info is empty
@@ -302,6 +286,20 @@ class PlainTextWidget(QWidget):
 	def __init__(self, window:QMainWindow, system_info):
 		super().__init__()
 		v_box = QVBoxLayout()
+		h_buttons = QHBoxLayout()
+
+		button_style = "background-color: #006699; padding-left:20px; padding-right:20px; padding-top:5px; padding-bottom:5px;"
+		data_as_string = ' '.join(str(s) for s in system_info)
+
+		self.clipboard_button = QPushButton("Copy to clipboard")
+		self.clipboard_button.setStyleSheet(button_style)
+		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(data_as_string))
+
+		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
+		self.website_button.setStyleSheet(button_style)
+		self.website_button.clicked.connect(lambda: sp.Popen(["firefox", "tarallo.weeeopen.it"]))
+		# TODO: don't hardcode it
+
 		plain_text = QPlainTextEdit()
 		plain_text.document().setPlainText(' '.join(str(s) for s in system_info))
 		plain_text.setStyleSheet("background-color:#333333; color:#bbbbbb")
@@ -311,6 +309,10 @@ class PlainTextWidget(QWidget):
 		back_button = QPushButton("Go back")
 		back_button.clicked.connect(lambda: self.restore_previous_window(window, system_info))
 
+		h_buttons.addWidget(self.clipboard_button)
+		h_buttons.addWidget(self.website_button)
+
+		v_box.addLayout(h_buttons)
 		v_box.addWidget(plain_text)
 		v_box.addWidget(back_button, alignment=Qt.AlignCenter)
 		self.setLayout(v_box)

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import subprocess as sp
+import json
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QPushButton, QMainWindow, QLabel, QWidget, \
 	QMessageBox, QScrollArea, QPlainTextEdit
 from PyQt5.QtGui import QFont, QIcon, QPalette, QColor
@@ -263,8 +264,6 @@ class VerifyExtractedData(QWidget):
 		self.setLayout(v_box)
 
 	def display_plaintext_data(self, window:QMainWindow, system_info):
-		if window.isMaximized():
-			window.showNormal()
 		window.takeCentralWidget()
 		plaintext_widget = PlainTextWidget(window, system_info)
 		window.setCentralWidget(plaintext_widget)
@@ -289,11 +288,11 @@ class PlainTextWidget(QWidget):
 		h_buttons = QHBoxLayout()
 
 		button_style = "background-color: #006699; padding-left:20px; padding-right:20px; padding-top:5px; padding-bottom:5px;"
-		data_as_string = ' '.join(str(s) for s in system_info)
+		copy_pastable_json = json.dumps(system_info, indent=2)
 
 		self.clipboard_button = QPushButton("Copy to clipboard")
 		self.clipboard_button.setStyleSheet(button_style)
-		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(data_as_string))
+		self.clipboard_button.clicked.connect(lambda: QApplication.clipboard().setText(copy_pastable_json))
 
 		self.website_button = QPushButton("Go to T.A.R.A.L.L.O.")
 		self.website_button.setStyleSheet(button_style)
@@ -301,7 +300,7 @@ class PlainTextWidget(QWidget):
 		# TODO: don't hardcode it
 
 		plain_text = QPlainTextEdit()
-		plain_text.document().setPlainText(' '.join(str(s) for s in system_info))
+		plain_text.document().setPlainText(copy_pastable_json)
 		plain_text.setStyleSheet("background-color:#333333; color:#bbbbbb")
 		plain_text.setMinimumSize(plain_text.width(), plain_text.height())
 		# prevent from resizing too much

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -202,8 +202,10 @@ class VerifyExtractedData(QWidget):
 
 		v_box = QVBoxLayout()
 
-		copy_button = QPushButton("Json")
-		v_box.addWidget(copy_button, alignment=Qt.AlignCenter)
+		# a button to copy data to the clipboard
+		clipboard_button = QPushButton("Json")
+		v_box.addWidget(clipboard_button, alignment=Qt.AlignCenter)
+		clipboard_button.setStyleSheet("background-color: blue")
 
 		# if system_info is empty
 		if not system_info:

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -302,16 +302,21 @@ class PlainTextWidget(QWidget):
 		v_box = QVBoxLayout()
 		plain_text = QPlainTextEdit()
 		plain_text.document().setPlainText(' '.join(str(s) for s in system_info))
-		plain_text.setStyleSheet("background-color:#333333; color:#aaaaaa")
+		plain_text.setStyleSheet("background-color:#333333; color:#bbbbbb")
 		plain_text.setMinimumSize(plain_text.width(), plain_text.height())
 		# prevent from resizing
 
 		back_button = QPushButton("Go back")
+		back_button.clicked.connect(lambda: self.restore_previous_window(window, system_info))
 
 		v_box.addWidget(plain_text)
 		v_box.addWidget(back_button, alignment=Qt.AlignCenter)
 		self.setLayout(v_box)
 
+	def restore_previous_window(self, window:QMainWindow, system_info):
+		window.takeCentralWidget()
+		extracted_data_scrollable = VerifyExtractedDataScrollable(window, system_info)
+		window.setCentralWidget(extracted_data_scrollable)
 
 def main():
 	app = QApplication(sys.argv)

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -205,7 +205,7 @@ class VerifyExtractedData(QWidget):
 		# a button to copy data to the clipboard
 		clipboard_button = QPushButton("Json")
 		v_box.addWidget(clipboard_button, alignment=Qt.AlignCenter)
-		clipboard_button.setStyleSheet("background-color: blue")
+		clipboard_button.setStyleSheet("background-color: #006699")
 
 		# if system_info is empty
 		if not system_info:

--- a/main_with_gui.py
+++ b/main_with_gui.py
@@ -202,6 +202,9 @@ class VerifyExtractedData(QWidget):
 
 		v_box = QVBoxLayout()
 
+		copy_button = QPushButton("Json")
+		v_box.addWidget(copy_button, alignment=Qt.AlignCenter)
+
 		# if system_info is empty
 		if not system_info:
 			nothing_found = QLabel("Nothing was found.")
@@ -269,7 +272,7 @@ def main():
 
 	# set SUPERIOR dark theme
 	app.setStyle('Fusion')
-	palette = QPalette()
+        palette = QPalette()
 	palette.setColor(QPalette.Window, QColor(53, 53, 53))
 	palette.setColor(QPalette.WindowText, Qt.white)
 	palette.setColor(QPalette.Base, QColor(15, 15, 15))


### PR DESCRIPTION
Referencing issue #36 
Main changes:
+ Added buttons in the scrollable window (copy to clipboard, proceed to JSON, go to T.A.R.A.L.L.O.)
+ Changed the scrollable window size to fullscreen to improve readability
+ Added notification when the text is copied into the clipboard 
+ Added JSON plain-text window, where the text is copy-pastable 
+ Go to T.A.R.A.L.L.O. button opens Firefox at the page tarallo.weeeopen.it when clicked